### PR TITLE
feature/integrate-user-settings-api-in-frontend

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\UserLearnWordController;
 use App\Http\Controllers\UserFollowersController;
 use App\Http\Controllers\UploadController;
 use App\Http\Controllers\ActivityController;
+use App\Http\Controllers\UserSettingsController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/register', [AuthController::class, 'register']);

--- a/frontend/src/components/UserSettings/UserDetailSettings/index.tsx
+++ b/frontend/src/components/UserSettings/UserDetailSettings/index.tsx
@@ -1,15 +1,46 @@
-import {FC,useState} from 'react';
+import { FC, useState, useEffect } from 'react';
+import { RootState } from '@store/reducers'
+import { ThunkDispatch } from 'redux-thunk';
+import { Action } from '@store/actions/index'
+import {
+  updateUserDetailSetting,
+  authCheckState
+} from '@store/actions/action-creator'
+import { bindActionCreators } from 'redux';
+import { connect, useDispatch } from 'react-redux';
+import User from '@model/userModels';
+import SpinnerButton from '@components/SVG/SpinnerBtn';
+import Swal from 'sweetalert2';
 
-const UserDetailSettings:FC = () =>{
+type Props = LinkStateProps & LinkDispatchProps;
 
+const UserDetailSettings: FC<Props> = ({
+  user, updateDetails,
+  saveLoading, error }) => {
+  const dispatch = useDispatch();
   const [input, setInput] = useState({
     fname: "",
     lname: "",
     mname: "",
     email: "",
-    password: "",
-    passwordConfirm: "",
   })
+
+  useEffect(() => {
+    user && setInput(user);
+  }, [])
+
+  const [errorState, setErrorState] = useState<any>([]);
+  const [isSuccessState, setIsSuccessState] = useState<boolean | null>
+    (null);
+
+  useEffect(() => {
+    if (error != null) {
+      let errorObj: any = eval(error);
+      setErrorState(errorObj.data.errors);
+    } else {
+      setErrorState("");
+    }
+  }, [error]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.persist();
@@ -25,74 +56,109 @@ const UserDetailSettings:FC = () =>{
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const formData = new FormData();
-    formData.set('email', input.email);
-    formData.set('fname', input.fname);
-    formData.set('mname', input.mname);
-    formData.set('lname', input.lname);
+    const { fname, lname, mname, email } = input;
+
+    updateDetails({ fname, lname, mname, email });
+    dispatch(authCheckState());
   }
 
-    return(
-        <form onSubmit={onSubmit} className="container pt-10 bg-none flex flex-col justify-self-start rounded-xl md:justify-center">
-        <div className="w-80 mb-2 mx-auto ">
-          <label htmlFor="fname" className="block font-sans text-lg text-white font-bold">
-            First name
-          </label>
-          <input
-            type="text"
-            name="fname"
-            id="fname"
-            value={(input && input.fname) || ""}
-            onChange={handleChange}
-            className="mt-2 mr-5 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        </div>
-        <div className="w-80 mb-2 mx-auto">
-          <label htmlFor="mname" className="block font-sans text-lg text-white font-bold">
-            Middle name
-          </label>
-          <input
-            type="text"
-            name="mname"
-            id="mname"
-            value={(input && input.mname) || ""}
-            onChange={handleChange}
-            className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        
-        </div>
-        <div className="w-80 mb-2 mx-auto">
-          <label htmlFor="lname" className="block font-sans text-lg text-white font-bold">
-            Last name
-          </label>
-          <input
-            type="text"
-            name="lname"
-            id="lname"
-            value={(input && input.lname) || ""}
-            onChange={handleChange}
-            className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        
-        </div>
-        <div className="w-80 mb-2 mx-auto">
-          <label htmlFor="email" className="block font-sans text-lg text-white font-bold">
-            Email
-          </label>
-          <input
-            type="text"
-            name="email"
-            id="email"
-            value={(input && input.email) || ""}
-            onChange={handleChange}
-            className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        </div>
-        <button         
-          className="py-2 mx-auto cursor-pointer border-none px-10 bg-indigo-800 font-sans rounded-full text-white font-bold uppercase text-sm mt-2"
-        >Update</button>
-      </form>
-    )
+  return (
+    <form onSubmit={onSubmit} className="container pt-10 bg-none flex flex-col justify-self-start rounded-xl md:justify-center">
+      {errorState &&
+        Object.keys(errorState).map((keys: any) => {
+          return (
+            <span className="block text-xs mx-auto mb-2 font-sans font-bold text-red-600">
+              {errorState[keys]}
+            </span>
+          )
+        })
+      }
+      <div className="w-80 mb-2 mx-auto ">
+        <label htmlFor="fname" className="block font-sans text-lg text-white font-bold">
+          First name
+        </label>
+        <input
+          type="text"
+          name="fname"
+          id="fname"
+          value={(input && input.fname) || ""}
+          onChange={handleChange}
+          className="mt-2 mr-5 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+      </div>
+      <div className="w-80 mb-2 mx-auto">
+        <label htmlFor="mname" className="block font-sans text-lg text-white font-bold">
+          Middle name
+        </label>
+        <input
+          type="text"
+          name="mname"
+          id="mname"
+          value={(input && input.mname) || ""}
+          onChange={handleChange}
+          className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+
+      </div>
+      <div className="w-80 mb-2 mx-auto">
+        <label htmlFor="lname" className="block font-sans text-lg text-white font-bold">
+          Last name
+        </label>
+        <input
+          type="text"
+          name="lname"
+          id="lname"
+          value={(input && input.lname) || ""}
+          onChange={handleChange}
+          className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+
+      </div>
+      <div className="w-80 mb-2 mx-auto">
+        <label htmlFor="email" className="block font-sans text-lg text-white font-bold">
+          Email
+        </label>
+        <input
+          type="text"
+          name="email"
+          id="email"
+          value={(input && input.email) || ""}
+          onChange={handleChange}
+          className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={saveLoading}
+
+        className="py-2 mx-auto cursor-pointer border-none px-10 bg-indigo-800 font-sans rounded-full text-white font-bold uppercase text-sm mt-2"
+      >
+        {saveLoading && (<SpinnerButton />)}
+        Update
+      </button>
+    </form>
+  )
 }
 
-export default UserDetailSettings;
+
+interface LinkStateProps {
+  user: User | null,
+  saveLoading: boolean,
+  error: string | null,
+}
+
+interface LinkDispatchProps {
+  updateDetails: (data: User) => void;
+}
+
+const mapDispatchToProps = (dispatch: ThunkDispatch<any, any, Action>, ownProps: any): LinkDispatchProps => ({
+  updateDetails: bindActionCreators(updateUserDetailSetting, dispatch),
+})
+
+const mapStateToProps = (state: RootState, ownProps: any): LinkStateProps => ({
+  user: state.auth.user,
+  saveLoading: state.userSetting.SaveLoading,
+  error: state.userSetting.error,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserDetailSettings);

--- a/frontend/src/components/UserSettings/UserPasswordSettings/index.tsx
+++ b/frontend/src/components/UserSettings/UserPasswordSettings/index.tsx
@@ -1,76 +1,143 @@
-import {FC,useState} from 'react';
+import { FC, useState, useEffect } from 'react';
+import { RootState } from '@store/reducers'
+import { ThunkDispatch } from 'redux-thunk';
+import { Action } from '@store/actions/index'
+import { updateUserPasswordSetting } from '@store/actions/action-creator'
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import User from '@model/userModels';
+import SpinnerButton from '@components/SVG/SpinnerBtn';
 
-const UserPasswordSettings:FC = () =>{
-    const [input, setInput] = useState({
-        oldPassword:"",
-        password: "",
-        passwordConfirm: "",
-      })
-    
-      const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        e.persist();
-        const name = e.target.name;
-        const value = e.target.value;
-    
-        setInput({
-          ...input,
-          [name]: value
+type Props = LinkStateProps & LinkDispatchProps;
+
+const UserPasswordSettings: FC<Props> = ({ updatePass, error, saveLoading }) => {
+  const [input, setInput] = useState({
+    current_password: "",
+    password: "",
+    passwordConfirm: "",
+  });
+
+  const [errorState, setErrorState] = useState<any>([]);
+
+  useEffect(() => {
+    if (error) {
+      let errorObj: any = eval(error);
+      setErrorState(errorObj.data.errors);
+    } else {
+      setErrorState("");
+    }
+  }, [error]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.persist();
+    const name = e.target.name;
+    const value = e.target.value;
+
+    setInput({
+      ...input,
+      [name]: value
+    })
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const formData = new FormData();
+    formData.set('current_password', input.current_password);
+    formData.set('password', input.password);
+    formData.set('password_confirmation', input.passwordConfirm);
+
+    updatePass(formData);
+  }
+  return (
+    <form onSubmit={onSubmit} className="container
+     pt-10 overflow-auto bg-none flex flex-col justify-self-start rounded-xl md:justify-center">
+      {errorState &&
+        Object.keys(errorState).map((keys: any) => {
+          return (
+            <span className="block text-xs mx-auto mb-2 font-sans font-bold text-red-600">
+              {errorState[keys]}
+            </span>
+          )
         })
       }
-    
-      const onSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-    
-        const formData = new FormData();
-      }
-    return(
-        <form onSubmit={onSubmit} className="container pt-10 bg-none flex flex-col justify-self-start rounded-xl md:justify-center">
-        
-        <div className="w-80 mb-2 mx-auto">
-          <label htmlFor="password" className="block font-sans text-lg text-white font-bold">
-            Old Password
-          </label>
-          <input
-            type="password"
-            name="password"
-            id="password"
-            value={(input && input.password) || ""}
-            onChange={handleChange}
-            className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        </div>
-        <div className="w-80 mb-2 mx-auto">
-          <label htmlFor="password" className="block font-sans text-lg text-white font-bold">
-            New Password
-          </label>
-          <input
-            type="password"
-            name="password"
-            id="password"
-            value={(input && input.password) || ""}
-            onChange={handleChange}
-            className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        </div>
-        <div className="w-80 mx-auto mb-2">
-          <label htmlFor="passwordConfirm" className="block font-sans text-lg text-white font-bold">
-            Confirmed Password
-          </label>
-          <input
-            type="password"
-            name="passwordConfirm"
-            id="passwordConfirm"
-            value={(input && input.passwordConfirm) || ""}
-            onChange={handleChange}
-            className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
-          />
-        </div>
+      <div className="w-80 mb-2 mx-auto">
+        <label htmlFor="current_password" className="block font-sans text-lg text-white font-bold">
+          Old Password
+        </label>
+        <input
+          type="password"
+          name="current_password"
+          id="current_password"
+          value={(input && input.current_password) || ""}
+          onChange={handleChange}
+          className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+      </div>
+      <div className="w-80 mb-2 mx-auto">
+        <label htmlFor="password" className="block font-sans text-lg text-white font-bold">
+          New Password
+        </label>
+        <input
+          type="password"
+          name="password"
+          id="password"
+          value={(input && input.password) || ""}
+          onChange={handleChange}
+          className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+      </div>
+      <div className="w-80 mx-auto mb-2">
+        <label htmlFor="passwordConfirm" className="block font-sans text-lg text-white font-bold">
+          Confirmed Password
+        </label>
+        <input
+          type="password"
+          name="passwordConfirm"
+          id="passwordConfirm"
+          value={(input && input.passwordConfirm) || ""}
+          onChange={handleChange}
+          className="mt-2 font-sans bg-white rounded-full  leading-tight text-lg py-2 text-black w-full"
+        />
+      </div>
 
-        <button         
-          className="py-2 mx-auto cursor-pointer border-none px-10 bg-indigo-800 font-sans rounded-full text-white font-bold uppercase text-sm mt-2"
-        >Update</button>
-      </form>
-    )
+      <button
+        disabled={saveLoading}
+        className="py-2 mx-auto cursor-pointer border-none px-10 
+        bg-indigo-800 font-sans rounded-full 
+        text-white font-bold uppercase text-sm mt-2"
+      >
+        {saveLoading && (
+          <SpinnerButton />
+        )}
+        Update
+      </button>
+    </form>
+  )
 }
 
-export default UserPasswordSettings;
+interface LinkStateProps {
+  user: User | null,
+  saveLoading: boolean,
+  error: string | null,
+
+}
+
+interface LinkDispatchProps {
+  updatePass: (data: FormData) => void;
+
+}
+
+const mapDispatchToProps = (dispatch: ThunkDispatch<any, any, Action>, ownProps: any): LinkDispatchProps => ({
+  updatePass: bindActionCreators(updateUserPasswordSetting, dispatch),
+
+})
+
+const mapStateToProps = (state: RootState, ownProps: any): LinkStateProps => ({
+  user: state.auth.user,
+  saveLoading: state.userSetting.SaveLoading,
+  error: state.userSetting.error,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserPasswordSettings);
+

--- a/frontend/src/components/UserSettings/UserSettings.module.css
+++ b/frontend/src/components/UserSettings/UserSettings.module.css
@@ -1,0 +1,20 @@
+.settingsBox {
+  @apply m-auto overflow-y-auto w-full lg:w-120 rounded-xl bg-gray-700 h-120;
+}
+
+.settingsBox::-webkit-scrollbar {
+  width: 5px;
+}
+
+.settingsBox::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 5px grey;
+  @apply rounded-lg;
+}
+
+.settingsBox::-webkit-scrollbar-thumb {
+  @apply bg-purple-600 rounded-lg;
+}
+
+.settingsBox::-webkit-scrollbar-thumb:hover {
+  @apply bg-purple-700;
+}

--- a/frontend/src/components/UserSettings/index.tsx
+++ b/frontend/src/components/UserSettings/index.tsx
@@ -1,25 +1,26 @@
-import {FC} from 'react';
+import { FC } from 'react';
 import { Redirect, Switch, Route, NavLink } from "react-router-dom";
 import UserDetailSettings from './UserDetailSettings';
 import UserPasswordSettings from './UserPasswordSettings';
+import classes from './UserSettings.module.css';
 
-const UserSettings:FC = () =>{
-    return(
-        <div className="m-auto w-full lg:w-120 rounded-xl bg-gray-700 h-120">
+const UserSettings: FC = () => {
+    return (
+        <div className={classes.settingsBox}>
             <div className="pl-5 py-2 bg-gray-900 text-white">
-              <h4>Settings</h4>
+                <h4>Settings</h4>
             </div>
-            <div className="flex px-10 py-5 bg-gray-900">
-                <NavLink className="ml-5" to="/Settings/UserDetails">Details</NavLink>
-                <NavLink className="ml-5" to="/Settings/UserPassword">Password</NavLink>
+            <div className="flex font-sans px-10 py-5 bg-gray-900">
+                <NavLink activeClassName="font-bold" className="ml-5" to="/Settings/UserDetails">Details</NavLink>
+                <NavLink activeClassName="font-bold" className="ml-5" to="/Settings/UserPassword">Password</NavLink>
             </div>
             <div>
                 <Switch>
                     <Route path="/Settings/UserDetails" exact >
-                        <UserDetailSettings/>
+                        <UserDetailSettings />
                     </Route>
                     <Route path="/Settings/UserPassword" exact >
-                        <UserPasswordSettings/>
+                        <UserPasswordSettings />
                     </Route>
                     <Redirect to="/Settings" />
                 </Switch>

--- a/frontend/src/store/actions/action-creator/index.ts
+++ b/frontend/src/store/actions/action-creator/index.ts
@@ -6,3 +6,4 @@ export * from './layoutAction';
 export * from './quizStudentActions';
 export * from './takeQuizAction';
 export * from './userStudentActions';
+export * from './userSettingAction';

--- a/frontend/src/store/actions/action-creator/userSettingAction.ts
+++ b/frontend/src/store/actions/action-creator/userSettingAction.ts
@@ -1,0 +1,34 @@
+import { UserSettingActionTypes } from '../action-types/';
+import User from '@model/userModels';
+import { Dispatch } from 'redux';
+import { Action } from '../';
+
+export const updateUserDetailSetting = (Data: User) => ({
+  type: UserSettingActionTypes.UPDATE_DETAILS_SETTINGS,
+  payload: {
+    meta: {
+      api: {
+        method: "post",
+        url: `/api/details`,
+        data: Data,
+      },
+    },
+  },
+});
+
+export const updateUserPasswordSetting = (Data: FormData) => ({
+  type: UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS,
+  payload: {
+    meta: {
+      api: {
+        method: "post",
+        url: `/api/password`,
+        data: Data,
+      },
+    },
+  },
+});
+
+export const startDetailsSettings = () => ({
+  type: UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_START,
+});

--- a/frontend/src/store/actions/action-types/index.ts
+++ b/frontend/src/store/actions/action-types/index.ts
@@ -6,6 +6,7 @@ import LayoutActionTypes from "./layoutActionTypes";
 import QuizStudentActionTypes from "./quizStudentActionTypes";
 import takeQuizStudentActionTypes from './takeQuizActionTypes'
 import UserStudentactiontypes from './userStudentActionTypes'
+import UserSettingActionTypes from './userSettingsActionTypes'
 
 export {
   QuizActionType,
@@ -15,6 +16,7 @@ export {
   LayoutActionTypes,
   QuizStudentActionTypes,
   takeQuizStudentActionTypes,
-  UserStudentactiontypes
+  UserStudentactiontypes,
+  UserSettingActionTypes
 };
 

--- a/frontend/src/store/actions/action-types/userSettingsActionTypes.ts
+++ b/frontend/src/store/actions/action-types/userSettingsActionTypes.ts
@@ -1,0 +1,13 @@
+enum UserSettingActions {
+
+  UPDATE_DETAILS_SETTINGS = "[UPDATE_DETAILS_SETTINGS] - update details setting data",
+  UPDATE_DETAILS_SETTINGS_START = "[UPDATE_DETAILS_SETTINGS_START] - update details start setting data",
+  UPDATE_DETAILS_SETTINGS_SUCCESS = "[UPDATE_DETAILS_SETTINGS] - update details setting data success",
+  UPDATE_DETAILS_SETTINGS_ERROR = "[UPDATE_DETAILS_SETTINGS] - update details setting data error",
+
+  UPDATE_PASSWORD_SETTINGS = "[UPDATE_PASSWORD_SETTINGS] - update password setting data",
+  UPDATE_PASSWORD_SETTINGS_SUCCESS = "[UPDATE_PASSWORD_SETTINGS] - update password setting data success",
+  UPDATE_PASSWORD_SETTINGS_ERROR = "[UPDATE_PASSWORD_SETTINGS] - update password setting data error",
+}
+
+export default UserSettingActions;

--- a/frontend/src/store/actions/index.ts
+++ b/frontend/src/store/actions/index.ts
@@ -6,6 +6,7 @@ import { LayoutAction } from "./layoutActions";
 import { StudentQuizAction } from './quizStudentActions';
 import { TakeQuizAction } from './takeQuestionActions';
 import { StudentUserAction } from './userStudentActions';
+import { UserSettingAction } from "./userSettingAction";
 
 export type Action =
   | QuizAction
@@ -15,5 +16,6 @@ export type Action =
   | LayoutAction
   | StudentQuizAction
   | TakeQuizAction
-  | StudentUserAction;
+  | StudentUserAction
+  | UserSettingAction;
 

--- a/frontend/src/store/actions/userSettingAction.ts
+++ b/frontend/src/store/actions/userSettingAction.ts
@@ -1,0 +1,44 @@
+import { UserSettingActionTypes } from "./action-types";
+
+
+interface UserDetailSettingUpdateDataAction {
+  type: UserSettingActionTypes.UPDATE_DETAILS_SETTINGS,
+}
+
+interface UserDetailSettingStartUpdateDataAction {
+  type: UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_START,
+}
+
+interface UserDetailSettingUpdateDataSuccessAction {
+  type: UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_SUCCESS,
+  payload: object,
+}
+
+interface UserDetailSettingUpdateDataFailAction {
+  type: UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_ERROR,
+  payload: string
+}
+
+interface UserPasswordSettingUpdateDataAction {
+  type: UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS,
+  id: string,
+}
+
+interface UserPasswordSettingUpdateDataSuccessAction {
+  type: UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS_SUCCESS,
+  payload: object,
+}
+
+interface UserPasswordSettingUpdateDataFailAction {
+  type: UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS_ERROR,
+  payload: string
+}
+
+export type UserSettingAction =
+  | UserDetailSettingUpdateDataAction
+  | UserDetailSettingUpdateDataSuccessAction
+  | UserDetailSettingUpdateDataFailAction
+  | UserPasswordSettingUpdateDataAction
+  | UserPasswordSettingUpdateDataSuccessAction
+  | UserPasswordSettingUpdateDataFailAction
+  | UserDetailSettingStartUpdateDataAction;

--- a/frontend/src/store/reducers/index.ts
+++ b/frontend/src/store/reducers/index.ts
@@ -9,11 +9,13 @@ import layoutReducer from './layoutReducer';
 import studentQuizReducer from './quizStudentReducer';
 import takeQuizReducer from './takeQuizReducer';
 import studentUserReducer from './userStudentReducer';
+import useSettingsReducer, { userSettingsSaga } from './userSettingReducer';
 
 export function* rootSaga() {
   yield all([...quizzesSaga]);
   yield all([...usersSaga]);
   yield all([...questionsSaga]);
+  yield all([...userSettingsSaga]);
 }
 
 const reducers = combineReducers({
@@ -25,6 +27,7 @@ const reducers = combineReducers({
   quizStudent: studentQuizReducer,
   takeQuiz: takeQuizReducer,
   userStudent: studentUserReducer,
+  userSetting: useSettingsReducer,
 });
 
 export default reducers;

--- a/frontend/src/store/reducers/userSettingReducer.ts
+++ b/frontend/src/store/reducers/userSettingReducer.ts
@@ -1,0 +1,101 @@
+import { UserSettingActionTypes } from '../actions/action-types/';
+import { Action } from '../actions'
+import { put, takeEvery, call } from "redux-saga/effects";
+import Swal from 'sweetalert2';
+import { startDetailsSettings } from '../actions/action-creator';
+
+interface QuizState {
+  error: string | null;
+  isSuccess: boolean | null;
+  SaveLoading: boolean,
+}
+
+export const initialState = {
+  error: null,
+  isSuccess: null,
+  SaveLoading: false,
+};
+
+
+const reducer = (
+  state: QuizState = initialState,
+  action: Action): QuizState => {
+
+  switch (action.type) {
+    case UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_START:
+      return {
+        ...state,
+        isSuccess: null,
+      };
+    case UserSettingActionTypes.UPDATE_DETAILS_SETTINGS:
+      return {
+        ...state,
+        SaveLoading: true,
+        isSuccess: null,
+      };
+    case UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_SUCCESS:
+      return {
+        ...state,
+        SaveLoading: false,
+        isSuccess: true,
+        error: null,
+      }
+    case UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_ERROR:
+      return {
+        ...state,
+        SaveLoading: false,
+        isSuccess: false,
+        error: action.payload,
+      }
+
+    case UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS:
+      return {
+        ...state,
+        SaveLoading: true,
+        isSuccess: null,
+      };
+    case UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS_SUCCESS:
+      return {
+        ...state,
+        SaveLoading: false,
+        isSuccess: true,
+        error: null,
+      }
+    case UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS_ERROR:
+      return {
+        ...state,
+        SaveLoading: false,
+        isSuccess: false,
+        error: action.payload
+      }
+    default:
+      return state;
+  }
+}
+
+export const userSettingsSaga = [
+  takeEvery(UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_SUCCESS, showAlert),
+  takeEvery(UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS_SUCCESS, showAlert),
+
+]
+
+function* showAlert(action: Action) {
+
+  Swal.fire({
+    icon: `success`,
+    title: 'successfully update',
+    showConfirmButton: false,
+    timer: 1500
+  });
+
+  yield call(startDetailsSaga, action);
+}
+
+function* startDetailsSaga(action: Action) {
+  if (action.type === UserSettingActionTypes.UPDATE_DETAILS_SETTINGS_SUCCESS
+    || UserSettingActionTypes.UPDATE_PASSWORD_SETTINGS_SUCCESS) {
+    yield put(startDetailsSettings());
+  }
+}
+
+export default reducer;


### PR DESCRIPTION
https://app.asana.com/0/1201258883888674/board
### **Commands**

_Backend_

- php artisan migrate
- php artisan serve

_Frontend_

- npm i
- npm start

### **Pre-condtions**
Able to see
```
Starting Laravel development server: http://127.0.0.1:8000
Starting development server: http://localhost:3000/
```

### **Expected Output**

- The user can change their basic details like name and password in the frontend

![image](https://user-images.githubusercontent.com/35307253/144347386-86a0d0ac-ddbf-479e-83de-255604cfd928.png)

![image](https://user-images.githubusercontent.com/35307253/144347440-1aeb9e44-2439-4c15-aee7-7789ee38fbcf.png)

![image](https://user-images.githubusercontent.com/35307253/144347508-f241f88a-9d6c-4f07-aaca-291b9c6cd2e4.png)
