### PR TITLE
bugfix/validation-message-in-registration-proper-format

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -19,8 +19,8 @@ class UserController extends Controller
         ];
 
         return $request->user()->tokenCan('adminAccess') ?
-            User::whereNotIn('Role', [$ROLE['STUDENT']])->get() :
-            User::whereNotIn('Role', [$ROLE['SUPER_ADMIN'], $ROLE['ADMIN']])
+            User::whereNotIn('role', [$ROLE['SUPER_ADMIN']])->get() :
+            User::with('followers', 'followings')->whereNotIn('role', [$ROLE['SUPER_ADMIN'], $ROLE['ADMIN']])
             ->whereNotIn('id', [$request->user()->id])
             ->paginate(8);
     }

--- a/backend/app/Http/Requests/RegisterRequest.php
+++ b/backend/app/Http/Requests/RegisterRequest.php
@@ -21,4 +21,14 @@ class RegisterRequest extends FormRequest
             'password' => 'required|string|confirmed|min:8'
         ];
     }
+
+    public function messages()
+    {
+
+        return [
+            'fname.required' => 'First name is required',
+            'lname.required' => 'Last name is required',
+            'mname.required' => 'Middle name is required',
+        ];
+    }
 }

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -23,9 +23,12 @@ class UserFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->name(),
+            'fname' => $this->faker->firstName(),
+            'lname' => $this->faker->lastName(),
+            'mname' => 'mn',
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
+            'role' => 2,
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
         ];

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $this->call(SuperAdminSeeder::class);
+        $this->call([
+            SuperAdminSeeder::class,
+            UserSeeder::class,
+        ]);
     }
 }

--- a/backend/database/seeders/UserSeeder.php
+++ b/backend/database/seeders/UserSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+
+    public function run()
+    {
+        User::factory()
+            ->count(10)->create();
+    }
+}


### PR DESCRIPTION
https://app.asana.com/0/1201258883888674/board
### **Commands**

_Backend_

- php artisan migrate
- php artisan serve

_Frontend_

- npm i
- npm start

### **Pre-condtions**
Able to see
```
Starting Laravel development server: http://127.0.0.1:8000
Starting development server: http://localhost:3000/
```

### **Expected Output**

- When the user register the error message for validation is properly format

![image](https://user-images.githubusercontent.com/35307253/144960554-bd9ad925-74b2-428d-a92d-7bf3c1e1f7b1.png)

