### PR TITLE
bugfix/newly-user-needs-quiz-reset-count-to-none

### DIFF
--- a/frontend/src/store/reducers/authReducer.ts
+++ b/frontend/src/store/reducers/authReducer.ts
@@ -91,6 +91,8 @@ const reducer = (
         token: action.idToken,
         userRole: action.userRole,
         user: action.user,
+        userLearnWords: [],
+        quizzesTaken: [],
         registerLoading: false,
         errorMessage: null,
       }


### PR DESCRIPTION
https://app.asana.com/0/1201258883888674/board
### **Commands**

_Backend_

- php artisan migrate
- php artisan serve

_Frontend_

- npm i
- npm start

### **Pre-condtions**
Able to see
```
Starting Laravel development server: http://127.0.0.1:8000
Starting development server: http://localhost:3000/
```

### **Expected Output**

- When the user register new account the dashboard show the correct learn words and learn quiz

![image](https://user-images.githubusercontent.com/35307253/144968188-b5102357-5c9d-4b98-947a-e3079d00fc30.png)



