### PR TITLE
bugfix/quiz-page-show-not-available-question-count-0

### DIFF
--- a/backend/app/Http/Controllers/QuizController.php
+++ b/backend/app/Http/Controllers/QuizController.php
@@ -14,7 +14,7 @@ class QuizController extends Controller
         return $request->user()->tokenCan('adminAccess') ?
             Quiz::all() : Quiz::withCount(['userAnswers' => function ($query) use ($user) {
                 return $query->where('user_id', $user->id);
-            }])
+            }, 'questions'])
             ->paginate(8);
     }
 

--- a/frontend/src/components/StudentQuiz/QuizCard/index.tsx
+++ b/frontend/src/components/StudentQuiz/QuizCard/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const QuizCard: FC<Props> = ({ quizData }) => {
 
-  const { id, title, description, user_answers_count } = quizData || {}
+  const { id, title, description, user_answers_count, questions_count } = quizData || {}
 
   const history = useHistory();
   const [DescriptionTruncate, setDescriptionTruncate] = useState(true);
@@ -59,9 +59,11 @@ const QuizCard: FC<Props> = ({ quizData }) => {
       </div>
       <div className="flex justify-end mt-4">
         <button
-          disabled={!!(user_answers_count && user_answers_count > 0)}
+          disabled={!!(!questions_count) || !!(user_answers_count && user_answers_count > 0)}
           onClick={() => alertQuiz(id)} className={classes.cardAction}>
-          {!!(user_answers_count && user_answers_count > 0) ? 'Already Done' : 'start'}
+          {
+            !!(user_answers_count && user_answers_count > 0) ?
+              'Already Done' : !!(questions_count) ? 'start' : 'Not Available'}
         </button>
       </div>
     </div>

--- a/frontend/src/models/quizModels.ts
+++ b/frontend/src/models/quizModels.ts
@@ -3,6 +3,7 @@ type Quiz = {
   title: string;
   description: string;
   user_answers_count?: number;
+  questions_count?: number;
 }
 
 export default Quiz;


### PR DESCRIPTION
https://app.asana.com/0/1201258883888674/board
### **Commands**

_Backend_

- php artisan migrate
- php artisan serve

_Frontend_

- npm i
- npm start

### **Pre-condtions**
Able to see
```
Starting Laravel development server: http://127.0.0.1:8000
Starting development server: http://localhost:3000/
```

### **Expected Output**

- when quiz has question is count to 0 then it will show not available

![image](https://user-images.githubusercontent.com/35307253/145323402-71779cb2-a051-4920-93b5-556e451f67b2.png)
